### PR TITLE
Preserve flag order across different file types

### DIFF
--- a/src/launch_utils.cpp
+++ b/src/launch_utils.cpp
@@ -22,39 +22,33 @@ bool has_extension(const std::string &filepath, const std::vector<std::string> &
 
 std::string build_launch_file_args(const std::vector<std::string> &selected_paths)
 {
-    std::string wad_files = "";
-    std::string deh_files = "";
-    std::string edf_files = "";
+    auto get_flag = [](const std::string &filepath) -> std::string
+    {
+        if (has_extension(filepath, DEH_EXTENSIONS)) return "-deh";
+        if (has_extension(filepath, EDF_EXTENSIONS)) return "-edf";
+        return "-file";
+    };
+
+    std::vector<std::string> flag_order;
+    std::map<std::string, std::string> flag_files;
 
     for (const auto &filepath : selected_paths)
     {
+        std::string flag = get_flag(filepath);
         std::string quoted = "\"" + filepath + "\" ";
-        if (has_extension(filepath, DEH_EXTENSIONS))
+
+        if (flag_files.find(flag) == flag_files.end())
         {
-            deh_files += quoted;
+            flag_order.push_back(flag);
+            flag_files[flag] = "";
         }
-        else if (has_extension(filepath, EDF_EXTENSIONS))
-        {
-            edf_files += quoted;
-        }
-        else
-        {
-            wad_files += quoted;
-        }
+        flag_files[flag] += quoted;
     }
 
     std::string result = "";
-    if (!wad_files.empty())
+    for (const auto &flag : flag_order)
     {
-        result += " -file " + wad_files;
-    }
-    if (!deh_files.empty())
-    {
-        result += " -deh " + deh_files;
-    }
-    if (!edf_files.empty())
-    {
-        result += " -edf " + edf_files;
+        result += " " + flag + " " + flag_files[flag];
     }
 
     return result;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@
 #error This backend requires SDL 2.0.17+ because of SDL_RenderGeometry() function
 #endif
 
-#define VERSION "0.1.15"
+#define VERSION "0.1.16"
 
 const std::vector<std::string> CONFIG_EXTENSIONS = {".cfg", ".ini"};
 

--- a/tests/launch_command_test.cpp
+++ b/tests/launch_command_test.cpp
@@ -81,7 +81,7 @@ TEST_CASE("Mixed file types produce correct grouped arguments")
     CHECK(result.find("-deh") != std::string::npos);
     CHECK(result.find("-edf") != std::string::npos);
 
-    // -file should come before -deh, which should come before -edf
+    // Flags appear in order of first selection: maps.wad (-file) first, patch.deh (-deh) second, root.edf (-edf) third
     size_t file_pos = result.find("-file");
     size_t deh_pos = result.find("-deh");
     size_t edf_pos = result.find("-edf");
@@ -98,6 +98,24 @@ TEST_CASE("Mixed file types produce correct grouped arguments")
 
     // EDF files should be grouped under -edf
     CHECK(result.find("root.edf") != std::string::npos);
+}
+
+TEST_CASE("Flag order follows selection order across different flag types")
+{
+    // DEH selected first, then WAD — should produce -deh before -file
+    std::vector<std::string> deh_first = {"bloodcolor.deh", "cblood.pk3"};
+    std::string result = build_launch_file_args(deh_first);
+    CHECK(result.find("-deh") < result.find("-file"));
+
+    // WAD selected first, then DEH — should produce -file before -deh
+    std::vector<std::string> wad_first = {"cblood.pk3", "bloodcolor.deh"};
+    result = build_launch_file_args(wad_first);
+    CHECK(result.find("-file") < result.find("-deh"));
+
+    // EDF selected first, then WAD — should produce -edf before -file
+    std::vector<std::string> edf_first = {"root.edf", "maps.wad"};
+    result = build_launch_file_args(edf_first);
+    CHECK(result.find("-edf") < result.find("-file"));
 }
 
 TEST_CASE("Empty file list produces empty result")


### PR DESCRIPTION
## Summary
- Fixes flag ordering when mixing file types (e.g. `-deh` and `-file`)
- Flags now appear in order of first selection instead of a hardcoded fixed order
- Selecting `bloodcolor.deh` then `cblood.pk3` now correctly produces `-deh bloodcolor.deh -file cblood.pk3`

Closes #25

## Test plan
- [x] Run `make test` — all 15 tests pass
- [x] Manually verify: select a `.deh` file first, then a `.pk3` — confirm `-deh` appears before `-file` in the launch command

🤖 Generated with [Claude Code](https://claude.com/claude-code)